### PR TITLE
fix-tvos-xcode-14

### DIFF
--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -163,9 +163,11 @@ internal struct EC {
                 let errorDomain = CFErrorGetDomain(cfError)
                 let errorCode = CFErrorGetCode(cfError)
 
-                #if canImport(LocalAuthentication)
-                if errorDomain == LAErrorDomain as CFErrorDomain {
-                    throw ECError.localAuthenticationFailed(errorCode: errorCode)
+                #if !os(tvOS)
+                if #available( macOS 10.11, iOS 8.3, watchOS 3.0, *)  {
+                    if errorDomain == LAErrorDomain as CFErrorDomain {
+                        throw ECError.localAuthenticationFailed(errorCode: errorCode)
+                    }
                 }
                 #endif
                 throw ECError.signingFailed(description: "Error creating signature. (CFError: \(cfError))")

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "JOSESwift",
-    platforms: [.iOS(.v10), .macOS(.v10_15), .watchOS(.v4)],
+    platforms: [.iOS(.v10), .macOS(.v10_15), .watchOS(.v4), .tvOS(.v13)],
     products: [
         .library(name: "JOSESwift", targets: ["JOSESwift"])
     ],


### PR DESCRIPTION
XCode 14.1 changes the `@available` macros for LAErrorDomain, and minor changes are required to compile.